### PR TITLE
Update date handling and fix #1

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -55,7 +55,7 @@ function updateCitationList() {
 
 function resetCitationList() {
     $("#citationList").html('Looks like you don\'t have any citations made yet!')
-    citations = ""
+    citations = []
 }
 
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -67,29 +67,30 @@ function getMLADate(year, month, day) {
     )
 }
 
+$(  // only start when DOM ready
+    $("#submitButton").on("click", event => {
+        event.preventDefault()
+        // Handle dates
+        let datePublished = getMLADate(
+            htmlEscape($("#datePublishedYear").val()),
+            htmlEscape($("#datePublishedMonth").val()) -1,
+            htmlEscape($("#datePublishedDay").val())
+        )
+        let dateAccessed = getMLADate(
+            htmlEscape($("#dateAccessedYear").val()),
+            htmlEscape($("#dateAccessedMonth").val()) - 1,
+            htmlEscape($("#dateAccessedDay").val())
+        )
+        citations.push(new WebCitation(
+            htmlEscape($("#authorLast").val()),
+            htmlEscape($("#authorFirst").val()),
+            htmlEscape($("#pageTitle").val()),
+            htmlEscape($("#siteTitle").val()),
+            datePublished,
+            dateAccessed,
+            htmlEscape($("#manualCiteURL").val())
+        ))
 
-$("#submitButton").on("click", event => {
-    event.preventDefault()
-    // Handle dates
-    let datePublished = getMLADate(
-        htmlEscape($("#datePublishedYear").val()),
-        htmlEscape($("#datePublishedMonth").val()) -1,
-        htmlEscape($("#datePublishedDay").val())
-    )
-    let dateAccessed = getMLADate(
-        htmlEscape($("#dateAccessedYear").val()),
-        htmlEscape($("#dateAccessedMonth").val()) - 1,
-        htmlEscape($("#dateAccessedDay").val())
-    )
-    citations.push(new WebCitation(
-        htmlEscape($("#authorLast").val()),
-        htmlEscape($("#authorFirst").val()),
-        htmlEscape($("#pageTitle").val()),
-        htmlEscape($("#siteTitle").val()),
-        datePublished,
-        dateAccessed,
-        htmlEscape($("#manualCiteURL").val())
-    ))
-    
-    updateCitationList()
-})
+        updateCitationList()
+    })
+)

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -59,27 +59,28 @@ function resetCitationList() {
 }
 
 
+function getMLADate(year, month, day) {
+    let date = new Date(year, month - 1, day)
+    return date.toLocaleDateString(
+        "en-GB", 
+        dateFormat = {day: "numeric", month: "long", year: "numeric"}
+    )
+}
+
 
 $("#submitButton").on("click", event => {
     event.preventDefault()
     // Handle dates
-    let datePublished = new Date(
+    let datePublished = getMLADate(
         htmlEscape($("#datePublishedYear").val()),
         htmlEscape($("#datePublishedMonth").val()) -1,
         htmlEscape($("#datePublishedDay").val())
     )
-    let dateAccessed = new Date(
+    let dateAccessed = getMLADate(
         htmlEscape($("#dateAccessedYear").val()),
         htmlEscape($("#dateAccessedMonth").val()) - 1,
         htmlEscape($("#dateAccessedDay").val())
     )
-    dateFormat = {
-        day: "numeric",
-        month: "long",
-        year: "numeric"
-    }
-    datePublished = datePublished.toLocaleDateString("en-GB", dateFormat)
-    dateAccessed = dateAccessed.toLocaleDateString("en-GB", dateFormat)
     citations.push(new WebCitation(
         htmlEscape($("#authorLast").val()),
         htmlEscape($("#authorFirst").val()),

--- a/index.html
+++ b/index.html
@@ -67,17 +67,17 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">Published:</span>
                             </div>
-                            <input type="text" placeholder="DD" id="datePublishedDay" class="form-control"/>
-                            <input type="text" placeholder="MM" id="datePublishedMonth" class="form-control"/>
-                            <input type="text" placeholder="YYYY" id="datePublishedYear" class="form-control"/>
+                            <input type="number" placeholder="DD" id="datePublishedDay" class="form-control"/>
+                            <input type="number" placeholder="MM" id="datePublishedMonth" class="form-control"/>
+                            <input type="number" placeholder="YYYY" id="datePublishedYear" class="form-control"/>
                         </div>
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text">Accessed:</span>
                             </div>
-                            <input type="text" placeholder="DD" id="dateAccessedDay" class="form-control"/>
-                            <input type="text" placeholder="MM" id="dateAccessedMonth" class="form-control"/>
-                            <input type="text" placeholder="YYYY" id="dateAccessedYear" class="form-control"/>
+                            <input type="number" placeholder="DD" id="dateAccessedDay" class="form-control"/>
+                            <input type="number" placeholder="MM" id="dateAccessedMonth" class="form-control"/>
+                            <input type="number" placeholder="YYYY" id="dateAccessedYear" class="form-control"/>
                         </div>
                         <!-- Submit/Reset -->
                             <div id="formButtons">


### PR DESCRIPTION
_Overview: This PR fixes #1, prevents jQuery actions before the DOM is safe, and simplifies manual citation dates both for the user and behind the scenes._

**Changelog:**
- Add `getMLADate()`, which, given params `year, month, day`, returns a MLA-formatted date string (such as `2 October 1999`, not `02 October 1999` or `2 Oct 1999` or `2 October '99`)
- Change the input `type` attribute to `"number"` to take advantage of browser numeric controls to adjust value
- Wrap jQuery event handlers in `$()` so they are not run before the DOM is ready to manipulate
- On reset of the citation list, change the `citations` variable to an empty array `[]` instead of the mistaken previous empty string `""`, which lacks the `.push()` method used to add a citation. This fixes #1.